### PR TITLE
Feature/streamline refresh token

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,4 @@
 import { Component } from '@angular/core';
-import { AuthService } from './services/auth.service';
-import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-root',

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,10 +13,10 @@ export class AppComponent {
   constructor(private http: HttpClient, private authService: AuthService) {}
 
   ngOnInit() {
-    // this.authService.login({
-    //   username: 'mathieu.theriault89@me.com',
-    //   password: 'a1032010',
-    // });
+    this.authService.login({
+      username: 'mathieu.theriault89@me.com',
+      password: 'a1032010',
+    });
     this.http.get('/expenses/all/643dc744faad3a88eab7e7ee').subscribe((res) => {
       console.log(res);
     });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { TokenInterceptor } from './interceptors/token.interceptor';
 import { BaseUrlInterceptor } from './interceptors/base-url.interceptor';
 import { AuthService } from './services/auth.service';
 import { TokenInjectorService } from './services/token-injector.service';
+import { RefreshTokenInterceptor } from './interceptors/refresh-token.interceptor';
 
 @NgModule({
   declarations: [AppComponent],
@@ -33,6 +34,11 @@ import { TokenInjectorService } from './services/token-injector.service';
     {
       provide: HTTP_INTERCEPTORS,
       useClass: TokenInterceptor,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: RefreshTokenInterceptor,
       multi: true,
     },
   ],

--- a/src/app/interceptors/refresh-token.interceptor.spec.ts
+++ b/src/app/interceptors/refresh-token.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RefreshTokenInterceptor } from './refresh-token.interceptor';
+
+describe('RefreshTokenInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      RefreshTokenInterceptor
+      ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: RefreshTokenInterceptor = TestBed.inject(RefreshTokenInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/interceptors/refresh-token.interceptor.ts
+++ b/src/app/interceptors/refresh-token.interceptor.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor,
+  HttpClient,
+} from '@angular/common/http';
+import { Observable, catchError } from 'rxjs';
+import { AuthService } from '../services/auth.service';
+import { TokenInjectorService } from '../services/token-injector.service';
+
+@Injectable()
+export class RefreshTokenInterceptor implements HttpInterceptor {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly tokenInjectorService: TokenInjectorService,
+    private readonly http: HttpClient
+  ) {}
+
+  private _request: HttpRequest<unknown> | null = null;
+  private _retryRequest: HttpRequest<unknown> | null = null;
+
+  // "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im1hdGhpZXUudGhlcmlhdWx0ODlAbWUuY29tIiwiaWF0IjoxNjgxODY1NDQwLCJleHAiOjE2ODE4NjkwNDB9.rzuHcZdcaciVEjL0lhReirt-ON92apgOJ9afP4gWSQk"
+
+  shouldRefreshToken(err: any, caugth: Observable<HttpEvent<any>>) {
+    if (
+      this._request &&
+      !(
+        this._request.url.includes('refresh') ||
+        this._request.url.includes('login') ||
+        this._request.url.includes('register')
+      )
+    ) {
+      if (err.status === 401) {
+        this._retryRequest = this._request;
+        console.log('shouldRefreshToken', err, caugth);
+        return true;
+      }
+    } else if (this._request && this._request.url.includes('refresh')) {
+      console.log(this._retryRequest);
+      this.retryRequest();
+    }
+
+    throw err;
+  }
+
+  tryRefreshToken(err: any, caugth: Observable<HttpEvent<any>>) {
+    if (this.shouldRefreshToken(err, caugth)) {
+      this._retryRequest = this._request;
+      this.authService.refreshToken();
+
+      return caugth;
+    }
+
+    throw err;
+  }
+
+  retryRequest() {
+    console.log('retryRequest', this._retryRequest);
+    if (this._retryRequest) {
+      const request = this.tokenInjectorService.injectToken(this._retryRequest);
+      console.log('retryRequest', request);
+      return this.http.request(request);
+    }
+
+    return null;
+  }
+
+  intercept(
+    request: HttpRequest<unknown>,
+    next: HttpHandler
+  ): Observable<HttpEvent<unknown>> {
+    this._request = request;
+    const handler = next.handle(request);
+    return handler.pipe(catchError(this.tryRefreshToken.bind(this)));
+  }
+}

--- a/src/app/interceptors/refresh-token.interceptor.ts
+++ b/src/app/interceptors/refresh-token.interceptor.ts
@@ -2,77 +2,39 @@ import { Injectable } from '@angular/core';
 import {
   HttpRequest,
   HttpHandler,
-  HttpEvent,
   HttpInterceptor,
-  HttpClient,
+  HttpStatusCode,
 } from '@angular/common/http';
-import { Observable, catchError } from 'rxjs';
+import { catchError, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
-import { TokenInjectorService } from '../services/token-injector.service';
+import { UserLogin } from '../interfaces/user-login.interface';
 
 @Injectable()
 export class RefreshTokenInterceptor implements HttpInterceptor {
-  constructor(
-    private readonly authService: AuthService,
-    private readonly tokenInjectorService: TokenInjectorService,
-    private readonly http: HttpClient
-  ) {}
+  constructor(private readonly authService: AuthService) {}
 
-  private _request: HttpRequest<unknown> | null = null;
-  private _retryRequest: HttpRequest<unknown> | null = null;
-
-  // "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6Im1hdGhpZXUudGhlcmlhdWx0ODlAbWUuY29tIiwiaWF0IjoxNjgxODY1NDQwLCJleHAiOjE2ODE4NjkwNDB9.rzuHcZdcaciVEjL0lhReirt-ON92apgOJ9afP4gWSQk"
-
-  shouldRefreshToken(err: any, caugth: Observable<HttpEvent<any>>) {
-    if (
-      this._request &&
-      !(
-        this._request.url.includes('refresh') ||
-        this._request.url.includes('login') ||
-        this._request.url.includes('register')
-      )
-    ) {
-      if (err.status === 401) {
-        this._retryRequest = this._request;
-        console.log('shouldRefreshToken', err, caugth);
-        return true;
-      }
-    } else if (this._request && this._request.url.includes('refresh')) {
-      console.log(this._retryRequest);
-      this.retryRequest();
-    }
-
-    throw err;
-  }
-
-  tryRefreshToken(err: any, caugth: Observable<HttpEvent<any>>) {
-    if (this.shouldRefreshToken(err, caugth)) {
-      this._retryRequest = this._request;
-      this.authService.refreshToken();
-
-      return caugth;
-    }
-
-    throw err;
-  }
-
-  retryRequest() {
-    console.log('retryRequest', this._retryRequest);
-    if (this._retryRequest) {
-      const request = this.tokenInjectorService.injectToken(this._retryRequest);
-      console.log('retryRequest', request);
-      return this.http.request(request);
-    }
-
-    return null;
-  }
-
-  intercept(
-    request: HttpRequest<unknown>,
-    next: HttpHandler
-  ): Observable<HttpEvent<unknown>> {
-    this._request = request;
-    const handler = next.handle(request);
-    return handler.pipe(catchError(this.tryRefreshToken.bind(this)));
+  intercept(request: HttpRequest<any>, next: HttpHandler) {
+    return next.handle(request).pipe(
+      catchError((error) => {
+        if (error.status === HttpStatusCode.Unauthorized) {
+          return this.authService.refreshToken()!.pipe(
+            switchMap((res) => {
+              const newRequest = request.clone({
+                setHeaders: {
+                  Authorization: `Bearer ${(res as UserLogin).token}`,
+                },
+              });
+              return next.handle(newRequest);
+            }),
+            catchError((error) => {
+              this.authService.logout();
+              return throwError(() => new Error(error));
+            })
+          );
+        } else {
+          return throwError(() => new Error(error));
+        }
+      })
+    );
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -55,21 +55,26 @@ export class AuthService {
 
     const { username, refresh_token } = user;
 
-    return this.http
-      .post<UserLogin | HttpError>(app.http.auth.refresh, {
+    const handler = this.http.post<UserLogin | HttpError>(
+      app.http.auth.refresh,
+      {
         refresh_token,
         username,
-      })
-      .subscribe((res) => {
-        if ('statusCode' in res) {
-          this.logout();
-          return;
-        }
+      }
+    );
 
-        this.tokenService.updateToken(res.token);
-        this.storageService.setItem(this.key, res.user);
-        this._isAuthenticated.next(true);
-      });
+    handler.subscribe((res) => {
+      if ('statusCode' in res) {
+        this.logout();
+        return;
+      }
+
+      this.tokenService.updateToken(res.token);
+      this.storageService.setItem(this.key, res.user);
+      this._isAuthenticated.next(true);
+    });
+
+    return handler;
   }
 
   logout() {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -46,7 +46,7 @@ export class AuthService {
       });
   }
 
-  async refreshToken() {
+  refreshToken() {
     const user = this.storageService.getItem<User>(this.key);
     if (!user) {
       this.logout();

--- a/src/app/services/token-injector.service.ts
+++ b/src/app/services/token-injector.service.ts
@@ -13,13 +13,8 @@ export class TokenInjectorService {
   }
 
   injectToken(request: HttpRequest<any>) {
-    console.log('injectToken', this.userToken);
-    const r = request.clone({
+    return request.clone({
       headers: request.headers.set('Authorization', `Bearer ${this.userToken}`),
     });
-
-    console.log('injectToken', r);
-
-    return r;
   }
 }

--- a/src/app/services/token-injector.service.ts
+++ b/src/app/services/token-injector.service.ts
@@ -13,8 +13,13 @@ export class TokenInjectorService {
   }
 
   injectToken(request: HttpRequest<any>) {
-    return request.clone({
+    console.log('injectToken', this.userToken);
+    const r = request.clone({
       headers: request.headers.set('Authorization', `Bearer ${this.userToken}`),
     });
+
+    console.log('injectToken', r);
+
+    return r;
   }
 }


### PR DESCRIPTION
- Modifié `refreshToken` dans le `AuthService` afin qu'il retourne un `Observable` au lieu d'une `Subscription`
- Ajouté un interceptor qui va vérifier si un code `401 Unauthorized` est renvoyé. Si oui, tentes de refresh le token. Si le token est bien refresh, injecte le token dans la requête puis clône cette requête et la retry.